### PR TITLE
I've made some updates to the Android build targets and improved the reliability of the workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -65,8 +65,8 @@ jobs:
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
           git add src-tauri/tauri.conf.json
-          git commit -m "ci: Android version bump to ${{ steps.bump_version.outputs.new_tag }} [skip ci]" || true
-          git push || true
+          git commit -m "ci: Android version bump to ${{ steps.bump_version.outputs.new_tag }} [skip ci]" || echo "No changes to commit"
+          git push
 
   build-tauri-android:
     needs: prepare-android-version
@@ -112,7 +112,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64,armv7,i686,x86_64
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
       - name: Verify Rust Android targets
         run: rustup target list --installed
       - name: Install Tauri CLI
@@ -128,7 +128,7 @@ jobs:
           VITE_LOGIN_URL: ${{ secrets.VITE_LOGIN_URL }}
         run: bun run vite build
       - name: Build Android APK
-        run: cargo tauri android build --target aarch64,armv7,i686,x86_64
+        run: cargo tauri android build --verbose --target aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
       - name: Upload Android APK
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,8 @@ jobs:
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
           git add src-tauri/tauri.conf.json
-          git commit -m "ci: desktop version bump to ${{ steps.bump_version.outputs.new_tag }} [skip ci]" || true
-          git push origin HEAD:${{ github.ref_name }} --follow-tags || true # Push commit and tags
+          git commit -m "ci: desktop version bump to ${{ steps.bump_version.outputs.new_tag }} [skip ci]" || echo "No changes to commit"
+          git push origin HEAD:${{ github.ref_name }} --follow-tags # Push commit and tags
 
   publish-tauri-linux:
     needs: prepare-release


### PR DESCRIPTION
- I updated the Rust targets in `android-release.yml` to the correct `*-linux-android*` variants.
- I added a `--verbose` flag to the Android build command for better error reporting.
- I ensured `git push` in version, bump steps will cause the job to fail if the push fails, rather than failing silently.
- I confirmed the versioning logic in both Android and desktop release workflows correctly updates `tauri.conf.json` before building.
- I verified that the build success criteria (allowing partial desktop releases while making errors visible, and failing the Android release on error) are met by the current workflow configurations.